### PR TITLE
Added missing feature flag to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 env_logger = "0.10.1"
+
+[features]
+parse-event-datetimes = []


### PR DESCRIPTION
I noticed the parse-event-datetimes feature was referenced, but wasn't made available via the cargo toml. Not sure if that was intentional or not, but I added it